### PR TITLE
add systemd daemon

### DIFF
--- a/systemd/readme.md
+++ b/systemd/readme.md
@@ -1,0 +1,30 @@
+## Debian系操作系统后台守护
+
+1. 将`zstarter.sh`复制到任意目录下，并把`RDIR`修改为zfile安装位置：
+
+```bash
+# Where does you installed zfile
+RDIR=/root/zfile
+```
+
+2. 将`zfile.service`复制到`/etc/systemd/system`目录下，并修改起始脚本位置，脚本放在哪就填写到哪：
+
+```bash
+[Service]
+ExecStart=/root/zstarter.sh
+```
+
+3. 启动服务并让他在后台运行
+
+```bash
+# 开机自启
+systemctl enable zfile
+# 后台运行
+systemctl start zfile
+# 终止
+systemctl stop zfile
+# 查看日志和状态
+systemctl status zfile
+# 取消开机自启
+systemctl disable zfile
+```

--- a/systemd/zfile.service
+++ b/systemd/zfile.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Zfile Daemon
+After=network.target
+
+[Service]
+ExecStart=/root/zstarter.sh
+Restart=always
+RestartSec=5
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/zstarter.sh
+++ b/systemd/zstarter.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Where does you installed zfile
+RDIR=/root/zfile
+
+cd $RDIR
+
+LIB_DIR=$RDIR/WEB-INF/lib
+LIB_JARS=`ls $LIB_DIR|grep .jar|awk '{print "'$LIB_DIR'/"$0}'|tr "\n" ":"`
+CLASSES=$RDIR/WEB-INF/classes
+JAVA_MEM_OPTS=" -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=utf-8 "
+JAVA_OPTS=" -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT+08"
+MAIN=im.zhaojun.zfile.ZfileApplication
+java $JAVA_OPTS $JAVA_MEM_OPTS -classpath $CLASSES:$LIB_JARS $MAIN


### PR DESCRIPTION
In order to solve the problem that the official start script of Zfile cannot automatically restart the process, the task of process guarding is handed over to systemd.